### PR TITLE
ROS2 Galactic Geochelone release

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,20 +1,19 @@
-pkgbase = ros2-foxy
+pkgbase = ros2-galactic
 	pkgdesc = A set of software libraries and tools for building robot applications
-	pkgver = 2020.12.11
+	pkgver = 2021.05.23
 	pkgrel = 3
-	url = https://docs.ros.org/en/foxy/
-	install = ros2-foxy.install
+	url = https://docs.ros.org/en/galactic/
+	install = ros2-galactic.install
 	arch = any
 	license = Apache
 	depends = ros2-arch-deps
 	depends = gmock
 	depends = sip4
-	source = ros2::git+https://github.com/ros2/ros2#tag=release-foxy-20201211
+	source = ros2::git+https://github.com/ros2/ros2#tag=release-galactic-20210523
+	source = google_benchmark_vendor.patch
 	source = mimick_vendor.patch
-	source = yaml_cpp_vendor.patch
 	sha256sums = SKIP
-	sha256sums = SKIP
-	sha256sums = SKIP
+	sha256sums = 609a5260736192608582c0f0a0fd4da09a9185d95d452a92d9527af38d720f6a
+	sha256sums = 9904000aa5f63e9aa600cb4a07b0caef48444f1dd6179a650242c0634cf5051e
 
-pkgname = ros2-foxy
-
+pkgname = ros2-galactic

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,14 @@
-*
+*.tar
+*.tar.*
+*.jar
+*.exe
+*.msi
+*.zip
+*.tgz
+*.log
+*.log.*
+*.sig
+
+pkg/
+src/
+ros2/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,62 +2,62 @@
 # Acknowledgment: This work is hugely based on `ros2-arch-deps` AUR
 # package, maintained by T. Borgert.
 
-pkgname=ros2-foxy
-pkgver=2020.12.11
+pkgname=ros2-galactic
+pkgver=2021.05.23
 pkgrel=3
 pkgdesc="A set of software libraries and tools for building robot applications"
-url="https://docs.ros.org/en/foxy/"
+url="https://docs.ros.org/en/galactic/"
 arch=('any')
 license=('Apache')
-depends=('ros2-arch-deps'
-         'gmock'
-         'sip4')
-source=("ros2::git+https://github.com/ros2/ros2#tag=release-foxy-20201211"
-        "mimick_vendor.patch"
-        "yaml_cpp_vendor.patch")
-sha256sums=('SKIP'
-            'SKIP'
-            'SKIP')
-install=ros2-foxy.install
+depends=(
+	'ros2-arch-deps'
+	'gmock'
+	'sip4'
+)
+source=(
+	"ros2::git+https://github.com/ros2/ros2#tag=release-galactic-20210523"
+	"google_benchmark_vendor.patch"
+	"mimick_vendor.patch"
+)
+sha256sums=(
+	'SKIP'
+	"609a5260736192608582c0f0a0fd4da09a9185d95d452a92d9527af38d720f6a"
+	"9904000aa5f63e9aa600cb4a07b0caef48444f1dd6179a650242c0634cf5051e"
+)
+install=ros2-galactic.install
 
 prepare() {
-    # Check locale
-    locale | grep LANG | grep UTF-8
-    if [[ $? -ne 0 ]]; then
-        printf "Locale must support UTF-8. See https://wiki.archlinux.org/index.php/locale
-        or https://wiki.archlinux.org/index.php/locale ."
-        exit 1
-    fi
+	# Check locale
+	locale | grep LANG | grep UTF-8
+	if [[ $? -ne 0 ]]; then
+		printf "Locale must support UTF-8. See https://wiki.archlinux.org/index.php/locale
+		or https://wiki.archlinux.org/index.php/locale ."
+		exit 1
+	fi
 
-    # Create required symlinks (see https://wiki.archlinux.org/index.php/ROS)
-    sudo mkdir -p /usr/share/sip
-    sudo ln -sf /usr/lib/python3.9/site-packages/PyQt5 /usr/share/sip/.
-    sudo ln -sf /usr/lib/python3.9/site-packages/PyQt5/bindings/* /usr/share/sip/PyQt5/.
+	# Clone the repos
+	mkdir -p $srcdir/ros2/src
+	vcs import $srcdir/ros2/src < $srcdir/ros2/ros2.repos
 
-    # Clone the repos
-    rm -rf $srcdir/ros2/src
-    mkdir -p $srcdir/ros2/src
-    vcs import $srcdir/ros2/src < $srcdir/ros2/ros2.repos
-
-    # Fix some issues in the code (TODO: Gradually move to upstream)
-    ## mimick_vendor:
-    git -C $srcdir/ros2/src/ros2/mimick_vendor cherry-pick c4f28e4f806fc3322d310bc3e93977df734ee733
-    patch --forward $srcdir/ros2/src/ros2/mimick_vendor/CMakeLists.txt mimick_vendor.patch
-    ## yaml_cpp_vendor:
-    patch --forward $srcdir/ros2/src/ros2/yaml_cpp_vendor/CMakeLists.txt yaml_cpp_vendor.patch
-    ## rcutils
-    git -C $srcdir/ros2/src/ros2/rcutils cherry-pick 618a9d94565ab844b9f40e0f5828ddbab2bcdad1
-    ## ros1_bridge
-    git -C $srcdir/ros2/src/ros2/ros1_bridge revert 81b7610568286ec7b390c64cf6207b362d0a6550 --no-edit
-    ## google_benchmark_vendor
-    git -C $srcdir/ros2/src/ament/google_benchmark_vendor checkout main
+	# Fix some issues in the code (TODO: Gradually move to upstream)
+	## mimick_vendor:
+	git -C $srcdir/ros2/src/ros2/mimick_vendor checkout .
+	git -C $srcdir/ros2/src/ros2/mimick_vendor apply $srcdir/mimick_vendor.patch
+	## google_benchmark_vendor
+	git -C $srcdir/ros2/src/ament/google_benchmark_vendor checkout .
+	git -C $srcdir/ros2/src/ament/google_benchmark_vendor apply $srcdir/google_benchmark_vendor.patch
+	## Eclipse iceoryx
+	git -C $srcdir/ros2/src/eclipse-iceoryx/iceoryx checkout release_1.0
+	## Eclipse CycloneDDS
+	git -C $srcdir/ros2/src/eclipse-cyclonedds/cyclonedds checkout 0.8.0beta6
+	git -C $srcdir/ros2/src/eclipse-cyclonedds/cyclonedds cherry-pick bdf270a588aae77d0f1a0f0070b53ad1388da61c
 }
 
 build() {
-    colcon build --merge-install
+	colcon build --merge-install
 }
 
 package() {
-    mkdir -p $pkgdir/opt/ros2/foxy
-    cp -r $srcdir/install/* $pkgdir/opt/ros2/foxy/
+	mkdir -p $pkgdir/opt/ros2/galactic
+	cp -r $srcdir/install/* $pkgdir/opt/ros2/galactic/
 }

--- a/google_benchmark_vendor.patch
+++ b/google_benchmark_vendor.patch
@@ -1,0 +1,101 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ec8f6e0..207dcab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@ endif()
+ macro(build_benchmark)
+   set(extra_cmake_args)
+ 
+-  set(GOOGLE_BENCHMARK_TARGET_VERSION "1.5.2")
++  set(GOOGLE_BENCHMARK_TARGET_VERSION "1.5.4")
+ 
+   if(DEFINED CMAKE_BUILD_TYPE)
+     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+@@ -66,9 +66,7 @@ macro(build_benchmark)
+       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
+       ${extra_cmake_args}
+     PATCH_COMMAND
+-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch &&
+-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/soversion.patch &&
+-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/shrink-tz-offset-size.patch
++      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
+   )
+ 
+   # The external project will install to the build folder, but we'll install that on make install.
+diff --git a/shrink-tz-offset-size.patch b/shrink-tz-offset-size.patch
+deleted file mode 100644
+index 9412e6a..0000000
+--- a/shrink-tz-offset-size.patch
++++ /dev/null
+@@ -1,52 +0,0 @@
+-From 07578d82e0a4f99bdd1546f4f6f1727109f9420d Mon Sep 17 00:00:00 2001
+-From: Chris Lalancette <clalancette@gmail.com>
+-Date: Fri, 9 Apr 2021 12:32:00 -0400
+-Subject: [PATCH] Shrink the tz_offset size to 41. (#1110)
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-When building with gcc TSan on, and in Debug mode, we see a warning
+-like:
+-
+-benchmark/src/timers.cc: In function ‘std::string benchmark::LocalDateTimeString()’:
+-src/timers.cc:241:15: warning: ‘char* strncat(char*, const char*, size_t)’ output may be truncated copying 108 bytes from a string of length 127 [-Wstringop-truncation]
+-  241 |   std::strncat(storage, tz_offset, sizeof(storage) - timestamp_len - 1);
+-      |   ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-
+-While this is essentially a false positive (we never expect
+-the number of bytes in tz_offset to be too large), the compiler can't
+-actually tell that.  Shrink the size of tz_offset to a smaller, but still safe
+-size to eliminate this warning.
+-
+-Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>
+----
+- src/timers.cc | 12 ++++++++++--
+- 1 file changed, 10 insertions(+), 2 deletions(-)
+-
+-diff --git a/src/timers.cc b/src/timers.cc
+-index 1d3ab9a..af4767d 100644
+---- a/src/timers.cc
+-+++ b/src/timers.cc
+-@@ -190,8 +190,16 @@ std::string LocalDateTimeString() {
+-   std::size_t timestamp_len;
+-   long int offset_minutes;
+-   char tz_offset_sign = '+';
+--  // Long enough buffers to avoid format-overflow warnings
+--  char tz_offset[128];
+-+  // tz_offset is set in one of three ways:
+-+  // * strftime with %z - This either returns empty or the ISO 8601 time.  The maximum length an
+-+  //   ISO 8601 string can be is 7 (e.g. -03:30, plus trailing zero).
+-+  // * snprintf with %c%02li:%02li - The maximum length is 41 (one for %c, up to 19 for %02li,
+-+  //   one for :, up to 19 %02li, plus trailing zero).
+-+  // * A fixed string of "-00:00".  The maximum length is 7 (-00:00, plus trailing zero).
+-+  //
+-+  // Thus, the maximum size this needs to be is 41.
+-+  char tz_offset[41];
+-+  // Long enough buffer to avoid format-overflow warnings
+-   char storage[128];
+- 
+- #if defined(BENCHMARK_OS_WINDOWS)
+--- 
+-2.26.3
+-
+diff --git a/soversion.patch b/soversion.patch
+deleted file mode 100644
+index 7255fb3..0000000
+--- a/soversion.patch
++++ /dev/null
+@@ -1,13 +0,0 @@
+-diff --git a/CMakeLists.txt b/CMakeLists.txt
+-index db0a6bfb..26ccf1a5 100644
+---- a/CMakeLists.txt	2020-07-15 17:35:35.557813957 -0700
+-+++ b/CMakeLists.txt	2020-07-15 17:36:19.040227189 -0700
+-@@ -79,7 +79,7 @@
+- 
+- # Read the git tags to determine the project version
+- include(GetGitVersion)
+--get_git_version(GIT_VERSION)
+-+#get_git_version(GIT_VERSION)
+- 
+- # Tell the user what versions we are using
+- string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" VERSION ${GIT_VERSION})

--- a/mimick_vendor.patch
+++ b/mimick_vendor.patch
@@ -1,3 +1,13 @@
-10a11,12
->   list(APPEND cmake_configure_args -DCMAKE_C_FLAGS="-O2")
->   list(APPEND cmake_configure_args -DCMAKE_CXX_FLAGS="-O2")
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e4cf591..54e4852 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,6 +8,8 @@ macro(build_mimick)
+ 
+   set(cmake_commands)
+   set(cmake_configure_args -Wno-dev)
++  list(APPEND cmake_configure_args -DCMAKE_C_FLAGS="-O2")
++  list(APPEND cmake_configure_args -DCMAKE_CXX_FLAGS="-O2")
+   list(APPEND cmake_configure_args -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install)
+ 
+   if(WIN32)

--- a/ros2-galactic.install
+++ b/ros2-galactic.install
@@ -1,3 +1,10 @@
+pre_install() {
+    # Create required symlinks (see https://wiki.archlinux.org/index.php/ROS)
+    mkdir -p /usr/share/sip
+    ln -sf /usr/lib/python3.9/site-packages/PyQt5 /usr/share/sip/.
+    ln -sf /usr/lib/python3.9/site-packages/PyQt5/bindings/* /usr/share/sip/PyQt5/.
+}
+
 post_install() {
     printf "
     \e[33m\e[1mIMPORTANT NOTE:\e[0m

--- a/yaml_cpp_vendor.patch
+++ b/yaml_cpp_vendor.patch
@@ -1,6 +1,0 @@
-18,19c18,19
-<     list(APPEND YAML_C_FLAGS "-w")
-<     list(APPEND YAML_CXX_FLAGS "-std=c++14 -w")
----
->     set(YAML_C_FLAGS "${YAML_C_FLAGS} -w")
->     set(YAML_CXX_FLAGS "${YAML_CXX_FLAGS} -std=c++14 -w")


### PR DESCRIPTION
Hi,
I've made a mostly-working PKGBUILD for Galactic based on your Foxy version.

This PR is mostly intended as a place for a discussion, though - as I'm not using Arch on a daily basis I don't want to push the package to AUR only to unmaintain it immediately.
If you'd be willing to take over, I'd be happy to transfer the ownership of the repository (or you could fork it back or pull it to another branch or something like that).

Few notes on my changes (besides switching to Galactic):
* I've reverted the packages to their mainline versions and then re-applied required patches one-by-one
* I've switched from using `diff` and `patch` to `git diff --patch` and `git apply` for generating and applying the aforementioned patches - I think it's cleaner and easier to maintain this way
* I've updated the `.gitignore` according to https://github.com/github/gitignore/blob/master/ArchLinuxPackages.gitignore
* I've moved the soft-linking of sip/PyQt5 into `pre_install()` (I'm not sure if that's required for building the package?)
* I've removed the re-downloading the whole source on a package rebuild and added `git checkout` for patched packages instead

And, just one more thing: when building the workspace I was running out of memory (4 threads, 8GB RAM) - adding `--executor sequential` limited the number of packages built simultaneously to 1 and solved the issue. What do you think about printing a note on that pre-build?