### PR TITLE
Fixed locale check

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,11 +22,10 @@ install=ros2-foxy.install
 
 prepare() {
     # Check locale
-    locale | grep LANG | grep UTF-8
-    if [[ $? -ne 0 ]]; then
-        printf "Locale must support UTF-8. See https://wiki.archlinux.org/index.php/locale
-        or https://wiki.archlinux.org/index.php/locale ."
-        exit 1
+    if [[ "$(locale | grep LANG | grep UTF-8)" == "" ]]; then
+      msg2 "ERROR: Locale must support UTF-8. See https://wiki.archlinux.org/index.php/locale or https://wiki.archlinux.org/index.php/locale";
+
+      exit 1;
     fi
 
     # Create required symlinks (see https://wiki.archlinux.org/index.php/ROS)


### PR DESCRIPTION
Before, no error message was produced when the locale check failed:
```
% LANG=C makepkg -o PKGBUILD                                                                     !10215
==> Making package: ros2-foxy 2020.12.11-3 (Sat 19 Jun 2021 01:07:41 PM CDT)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Updating ros2 git repo...
Fetching origin
  -> Found mimick_vendor.patch
  -> Found yaml_cpp_vendor.patch
==> Validating source files with sha256sums...
    ros2 ... Skipped
    mimick_vendor.patch ... Skipped
    yaml_cpp_vendor.patch ... Skipped
==> Extracting sources...
  -> Creating working copy of ros2 git repo...
Reset branch 'makepkg'
==> Starting prepare()...
==> ERROR: A failure occurred in prepare().
    Aborting...
```

Fixed:
```
% LANG=C makepkg -o PKGBUILD                                                                                                                                                                                !10206
==> Making package: ros2-foxy 2020.12.11-3 (Sat 19 Jun 2021 01:06:09 PM CDT)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Updating ros2 git repo...
Fetching origin
  -> Found mimick_vendor.patch
  -> Found yaml_cpp_vendor.patch
==> Validating source files with sha256sums...
    ros2 ... Skipped
    mimick_vendor.patch ... Skipped
    yaml_cpp_vendor.patch ... Skipped
==> Extracting sources...
  -> Creating working copy of ros2 git repo...
Reset branch 'makepkg'
==> Starting prepare()...
  -> ERROR: Locale must support UTF-8. See https://wiki.archlinux.org/index.php/locale or https://wiki.archlinux.org/index.php/locale
```

The issue was that returning an error code from `locale | grep LANG | grep UTF-8` would cause the prepare hook to fail immediately.